### PR TITLE
Documentation updates, from/imports, environment variable name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ awsstats
 
 AWS services' statistics...simplified!
 
+## Install
+
+`pip install git+https://github.com/sparkgeo/awsstats.git`
+
 ## Requires
 
 * boto3

--- a/awsstats/dynamodb.py
+++ b/awsstats/dynamodb.py
@@ -1,4 +1,4 @@
-import utils
+from awsstats import utils
 
 __all__ = ('get_avg_read_capacity',
            'get_avg_write_capacity',)

--- a/awsstats/ec2.py
+++ b/awsstats/ec2.py
@@ -1,4 +1,4 @@
-import utils
+from awsstats import utils
 
 __all__ = ('get_avg_cpu',)
 

--- a/awsstats/rds.py
+++ b/awsstats/rds.py
@@ -1,4 +1,4 @@
-import utils
+import .utils
 
 __all__ = ('get_avg_cpu',
            'get_avg_read_iops',


### PR DESCRIPTION
- sticking to standard AWS environment variables naming
- Update docs to reflect env. variable naming changes
- imports for utils stick to full from/import

resolves https://github.com/sparkgeo/awsstats/issues/1